### PR TITLE
Simplifications for oneDPL use of maxloc example

### DIFF
--- a/Libraries/oneDPL/maxloc_reductions/maxloc_usm.cpp
+++ b/Libraries/oneDPL/maxloc_reductions/maxloc_usm.cpp
@@ -7,11 +7,10 @@
 
 int main() {
 
-    sycl::queue Q(sycl::default_selector{});
-    auto policy = oneapi::dpl::execution::make_device_policy(Q);
+    auto policy = oneapi::dpl::execution::dpcpp_default;
 
     const size_t n = 7;
-    auto data = sycl::malloc_shared<int>(n, Q);
+    auto data = sycl::malloc_shared<int>(n, policy.queue());
 
     data[0] = 2;
     data[1] = 2;
@@ -22,7 +21,6 @@ int main() {
     data[6] = 1;
 
     auto maxloc = oneapi::dpl::max_element(policy, data, data + n);
-    policy.queue().wait();
 
     std::cout << "Run on "
               << policy.queue().get_device().template
@@ -32,6 +30,6 @@ int main() {
               << oneapi::dpl::distance(data, maxloc)
               << std::endl;
 
-    sycl::free(data, Q);
+    sycl::free(data, policy.queue());
     return 0;
 }


### PR DESCRIPTION
# Reducing LOC of maxloc example (USM version)
## Description

This PR adds use of more oneDPL functionality (default execution policy, blocking behavior) to reduce LOC of maxloc example (USM version).

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
